### PR TITLE
Tidy layout

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Encoding: UTF-8
 LazyData: true
 ByteCompile: true
 License: GPL-3 + file LICENSE
-RoxygenNote: 6.0.1.9000
+RoxygenNote: 6.1.0
 Imports: 
     snakecase,
     purrr,

--- a/R/create_workshop_certificate.R
+++ b/R/create_workshop_certificate.R
@@ -8,6 +8,8 @@
 #' @param credentials Credentials of the certifying person, character.
 #' @param attendees Names of attendees, character vector.
 #' @param dir Directory where to output the pdf certificates, character.
+#' @param papersize Option for LaTeX article class specifying paper size, e.g.
+#' `"a4paper"`, `"letterpaper"`.
 #' @param keep_tex Logical argument passed to rmarkdown::render
 #'
 #' @export
@@ -31,10 +33,10 @@
 #' attendees,
 #' dir)
 #' }
-create_workshop_certificates <- function(date, location, workshop, curriculum, certifier,
-                                        credentials,
-                                        attendees,
-                                        dir, keep_tex = FALSE){
+create_workshop_certificates <- function(date, location, workshop, curriculum,
+                                         certifier, credentials, attendees,
+                                         dir, papersize = "a4paper",
+                                         keep_tex = FALSE){
 
     if(!dir.exists(dir)){
         dir.create(dir)
@@ -53,11 +55,11 @@ create_workshop_certificates <- function(date, location, workshop, curriculum, c
 
 
     purrr::walk2(attendees, 1:length(attendees),
-               create_workshop_certificate,
-               date, location, workshop,
-               curriculum, certifier,
-               credentials,
-               dir, keep_tex)
+                 create_workshop_certificate,
+                 date, location, workshop,
+                 curriculum, certifier,
+                 credentials,
+                 dir, papersize, keep_tex)
 
    file.remove(file.path(dir, "skeleton.Rmd"))
    file.remove(file.path(dir, "file.tex"))
@@ -69,13 +71,14 @@ create_workshop_certificate <- function(attendee, number,
                                         date, location, workshop,
                                         curriculum, certifier,
                                         credentials,
-                                        dir, keep_tex){
+                                        dir, papersize, keep_tex){
     rmarkdown::render(input = file.path(dir, "skeleton.Rmd"),
                       output_file = paste0(snakecase::to_snake_case(paste(workshop,
                                                                    stringr::str_pad(number, 2, pad = "0"))),
                                            ".pdf"),
                       output_dir = dir,
-                      params = list(date = date,
+                      params = list(papersize = papersize,
+                                    date = date,
                                     location = location,
                                     workshop = workshop,
                                     curriculum = curriculum,

--- a/branding.Rproj
+++ b/branding.Rproj
@@ -10,7 +10,7 @@ NumSpacesForTab: 4
 Encoding: UTF-8
 
 RnwWeave: knitr
-LaTeX: pdfLaTeX
+LaTeX: XeLaTeX
 
 AutoAppendNewline: Yes
 StripTrailingWhitespace: Yes

--- a/inst/rmarkdown/templates/workshop_certificate/skeleton/file.tex
+++ b/inst/rmarkdown/templates/workshop_certificate/skeleton/file.tex
@@ -9,9 +9,9 @@
 \fancyhf{}
 \renewcommand{\headrulewidth}{0pt}
 \renewcommand{\footrulewidth}{0pt}
-\fancyfoot[CO,CE]{Forwards, the R Foundation taskforce on women and other under-represented groups. \href{https://forwards.github.io/}{\nolinkurl{forwards.github.io/}}}
+\fancyfoot[CO,CE]{Forwards, the R Foundation taskforce on women and other under-represented groups: \href{https://forwards.github.io/}{\nolinkurl{forwards.github.io/}}}
 \fancypagestyle{plain}{%  the preset of fancyhdr
     \fancyhf{}
     \renewcommand{\headrulewidth}{0pt}
     \renewcommand{\footrulewidth}{0pt}
-    \fancyfoot[CO,CE]{Forwards, the R Foundation taskforce on women and other under-represented groups. \href{https://forwards.github.io/}{\nolinkurl{forwards.github.io/}}}}
+    \fancyfoot[CO,CE]{Forwards, the R Foundation taskforce on women and other under-represented groups: \href{https://forwards.github.io/}{\nolinkurl{forwards.github.io/}}}}

--- a/inst/rmarkdown/templates/workshop_certificate/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/workshop_certificate/skeleton/skeleton.Rmd
@@ -9,6 +9,10 @@ output:
 documentclass: extarticle        
 fontsize: 14pt
 params:
+  papersize:
+    label: Paper size of output PDF
+    value: a4paper
+    input: text    
   date: 
     label: Date of workshop
     value: !r lubridate::today() 
@@ -36,6 +40,10 @@ params:
     label: Attendee
     value: Maëlle Salmon
     input: text
+---
+
+---
+classoption: "`r params$papersize`"
 ---
 
 \CenterWallPaper{1}{logo.png}

--- a/inst/rmarkdown/templates/workshop_certificate/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/workshop_certificate/skeleton/skeleton.Rmd
@@ -6,7 +6,8 @@ output:
             in_header: file.tex
         latex_engine: xelatex
         keep_tex: false
-fontsize: 12pt
+documentclass: extarticle        
+fontsize: 14pt
 params:
   date: 
     label: Date of workshop

--- a/man/create_workshop_certificates.Rd
+++ b/man/create_workshop_certificates.Rd
@@ -4,8 +4,9 @@
 \alias{create_workshop_certificates}
 \title{Create certificates for all attendees}
 \usage{
-create_workshop_certificates(date, location, workshop, curriculum, certifier,
-  credentials, attendees, dir, keep_tex = FALSE)
+create_workshop_certificates(date, location, workshop, curriculum,
+  certifier, credentials, attendees, dir, papersize = "a4paper",
+  keep_tex = FALSE)
 }
 \arguments{
 \item{date}{Date of the workshop, as a date.}
@@ -23,6 +24,9 @@ create_workshop_certificates(date, location, workshop, curriculum, certifier,
 \item{attendees}{Names of attendees, character vector.}
 
 \item{dir}{Directory where to output the pdf certificates, character.}
+
+\item{papersize}{Option for LaTeX article class specifying paper size, e.g.
+`"a4paper"`, `"letterpaper"`.}
 
 \item{keep_tex}{Logical argument passed to rmarkdown::render}
 }


### PR DESCRIPTION
This PR addresses the remaining issues in the tasklist in #6.

1. Larger font for main content (possibly also title/footer). This is implemented by using extarticle vs article class. I have used 14pt for now - as this means the long name of the taskforce runs over 2 lines I added a colon before the web address. (I also added a space before "Workshop contents" so it was not on the same line as the location).

2.  Enable page size to be customized (currently US letter). This is implemented by an option to the extarticle class, which can be specified by an argument in `create_workshop_certificates` which is passed to a parameter in the R markdown template.